### PR TITLE
Add secondary bitmap handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>iso8583-library</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>ISO8583 Library</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.example.iso8583.App</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/iso8583/App.java
+++ b/src/main/java/com/example/iso8583/App.java
@@ -1,0 +1,29 @@
+package com.example.iso8583;
+
+/**
+ * Simple application example for parsing a fixed ISO8583 message and printing
+ * the JSON representation.
+ */
+public class App {
+    public static void main(String[] args) {
+        // Example ISO8583 message string demonstrating both primary and
+        // secondary bitmaps. Format:
+        // MTI + primary bitmap [+ secondary bitmap] + data elements
+        String message = "0200" +
+                "F238000000000000" + // Primary bitmap: fields 2,3,4,7,11,12,13 and secondary indicator
+                "0400000000000000" + // Secondary bitmap: field 70
+                "1234567890123456" + // Field 2
+                "000000" +             // Field 3
+                "000000010000" +       // Field 4
+                "0707221800" +         // Field 7
+                "123456" +             // Field 11
+                "221800" +             // Field 12
+                "0707" +               // Field 13
+                "001";                // Field 70
+
+        Iso8583Parser parser = new Iso8583Parser();
+        Iso8583Message isoMsg = parser.parse(message);
+
+        System.out.println(isoMsg.toJson());
+    }
+}

--- a/src/main/java/com/example/iso8583/Iso8583Message.java
+++ b/src/main/java/com/example/iso8583/Iso8583Message.java
@@ -1,0 +1,52 @@
+package com.example.iso8583;
+
+import java.util.Map;
+import java.util.LinkedHashMap;
+
+/**
+ * Represents a parsed ISO8583 message with data elements stored in a map.
+ */
+public class Iso8583Message {
+    private String mti;
+    private Map<Integer, String> dataElements = new LinkedHashMap<>();
+
+    public String getMti() {
+        return mti;
+    }
+
+    public void setMti(String mti) {
+        this.mti = mti;
+    }
+
+    public void setDataElement(int field, String value) {
+        dataElements.put(field, value);
+    }
+
+    public String getDataElement(int field) {
+        return dataElements.get(field);
+    }
+
+    public Map<Integer, String> getAllDataElements() {
+        return dataElements;
+    }
+
+    /**
+     * Returns a simple JSON representation of this message.
+     */
+    public String toJson() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n  \"mti\": \"").append(mti).append("\",");
+        sb.append("\n  \"dataElements\": {");
+        boolean first = true;
+        for (Map.Entry<Integer, String> entry : dataElements.entrySet()) {
+            if (!first) {
+                sb.append(",");
+            }
+            sb.append("\n    \"").append(entry.getKey()).append("\": \"")
+              .append(entry.getValue()).append("\"");
+            first = false;
+        }
+        sb.append("\n  }\n}");
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/example/iso8583/Iso8583Parser.java
+++ b/src/main/java/com/example/iso8583/Iso8583Parser.java
@@ -1,0 +1,91 @@
+package com.example.iso8583;
+
+import java.util.BitSet;
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+ * A very small ISO8583 parser example. This is NOT production ready and only
+ * demonstrates parsing of a simple bitmap message with fixed-length fields.
+ */
+public class Iso8583Parser {
+
+    // Basic length for a primary or secondary bitmap (64 bits => 16 hex chars)
+    private static final int BITMAP_LENGTH = 16;
+
+    // Example field lengths for a few data elements. Fields not listed will be
+    // treated as simple LLVAR (length encoded with two digits).
+    private static final Map<Integer, Integer> FIELD_LENGTHS = new HashMap<>();
+    static {
+        // Field number -> length in characters (for demonstration)
+        FIELD_LENGTHS.put(2, 16);  // Primary account number (PAN)
+        FIELD_LENGTHS.put(3, 6);   // Processing code
+        FIELD_LENGTHS.put(4, 12);  // Amount, transaction
+        FIELD_LENGTHS.put(7, 10);  // Transmission date & time
+        FIELD_LENGTHS.put(11, 6);  // Systems trace audit number
+        FIELD_LENGTHS.put(12, 6);  // Time, local transaction
+        FIELD_LENGTHS.put(13, 4);  // Date, local transaction
+        FIELD_LENGTHS.put(70, 3);  // Network management information code
+    }
+
+    /**
+     * Parses a raw ISO8583 message string assuming ASCII encoding. This method
+     * supports both primary and secondary bitmaps and falls back to LLVAR for
+     * fields without configured fixed lengths.
+     */
+    public Iso8583Message parse(String message) {
+        Iso8583Message isoMsg = new Iso8583Message();
+        int index = 0;
+
+        // Parse MTI (4 chars)
+        String mti = message.substring(index, index + 4);
+        isoMsg.setMti(mti);
+        index += 4;
+
+        // Parse primary bitmap (16 hex characters => 64 bits)
+        String bitmapHex = message.substring(index, index + BITMAP_LENGTH);
+        index += BITMAP_LENGTH;
+
+        BitSet bitmap = parseBitmap(bitmapHex);
+
+        // If the first bit is set a secondary bitmap follows
+        if (bitmap.get(0)) {
+            String secondaryHex = message.substring(index, index + BITMAP_LENGTH);
+            index += BITMAP_LENGTH;
+            BitSet secondary = parseBitmap(secondaryHex);
+            for (int i = 0; i < 64; i++) {
+                bitmap.set(64 + i, secondary.get(i));
+            }
+        }
+
+        // Parse fields indicated in bitmap
+        for (int field = 2; field <= 128; field++) {
+            if (bitmap.get(field - 1)) { // bitmap bit positions start at 0
+                Integer length = FIELD_LENGTHS.get(field);
+                String value;
+                if (length != null && length > 0) {
+                    value = message.substring(index, index + length);
+                    index += length;
+                } else {
+                    // Default to LLVAR (2 digit length prefix)
+                    int len = Integer.parseInt(message.substring(index, index + 2));
+                    index += 2;
+                    value = message.substring(index, index + len);
+                    index += len;
+                }
+                isoMsg.setDataElement(field, value);
+            }
+        }
+
+        return isoMsg;
+    }
+
+    private BitSet parseBitmap(String hex) {
+        byte[] bytes = new byte[hex.length() / 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int pos = i * 2;
+            bytes[i] = (byte) Integer.parseInt(hex.substring(pos, pos + 2), 16);
+        }
+        return BitSet.valueOf(bytes);
+    }
+}


### PR DESCRIPTION
## Summary
- support primary and secondary bitmaps in `Iso8583Parser`
- default unknown field lengths to LLVAR
- add field 70 sample length
- update example message in `App`

## Testing
- `mvn -q package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681a434cec8327b867f91a91603ca7